### PR TITLE
ci: add dependabot config for github-actions with 30-day cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,6 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
     cooldown:
       default-days: 30

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 30


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` to keep GitHub Actions versions current via monthly Dependabot scans, with a 30-day cooldown before opening PRs for new releases.

## Test plan
- [ ] Dependabot picks up the config and surfaces any pending Actions updates after the cooldown window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)