### PR TITLE
ci: delegate code-examples commit/push to shared action

### DIFF
--- a/.github/workflows/extract-code-examples.yml
+++ b/.github/workflows/extract-code-examples.yml
@@ -17,19 +17,15 @@ jobs:
     # which doesn't exist in this repo, and we can't push back to a fork anyway.
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+
+    env:
+      # Quoted indirection: keeps untrusted ref values out of inline ${{ }}
+      # shell expansions per GitHub's workflow-injection guidance.
+      HEAD_REF: ${{ github.event.pull_request.head.ref }}
+
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ env.HEAD_REF }}
 
       - uses: PhenoML/sdk-shared-actions/extract-code-examples@main
-
-      - name: Commit code-examples.json if changed
-        run: |
-          git add code-examples.json
-          if ! git diff --cached --quiet -- code-examples.json; then
-            git config user.name "github-actions[bot]"
-            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-            git commit -m "chore: update code-examples.json"
-            git push
-          fi

--- a/.github/workflows/extract-code-examples.yml
+++ b/.github/workflows/extract-code-examples.yml
@@ -17,15 +17,9 @@ jobs:
     # which doesn't exist in this repo, and we can't push back to a fork anyway.
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
-
-    env:
-      # Quoted indirection: keeps untrusted ref values out of inline ${{ }}
-      # shell expansions per GitHub's workflow-injection guidance.
-      HEAD_REF: ${{ github.event.pull_request.head.ref }}
-
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          ref: ${{ env.HEAD_REF }}
+          ref: ${{ github.head_ref }}
 
       - uses: PhenoML/sdk-shared-actions/extract-code-examples@main


### PR DESCRIPTION
## Summary
- Drop the inline commit/push block from `extract-code-examples.yml` — the shared action now self-commits with rebase-and-retry ([sdk-shared-actions#16](https://github.com/PhenoML/sdk-shared-actions/pull/16)) to absorb concurrent-workflow races against `bundle-openapi-spec`.

## Test plan
- [ ] Land sdk-shared-actions#16 first (this workflow pins `@main`), then open a fresh Fern PR and confirm both `extract-code-examples` and `bundle-openapi-spec` push without non-fast-forward rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes a GitHub Actions workflow that auto-commits to PR branches; mistakes could break CI updates or cause unexpected pushes/rebase behavior. Scope is small and limited to CI configuration.
> 
> **Overview**
> The `extract-code-examples` GitHub Actions workflow now delegates updating `code-examples.json` entirely to `PhenoML/sdk-shared-actions/extract-code-examples@main`, removing the inline `git add/commit/push` step.
> 
> This shifts commit/retry behavior into the shared action, changing how the workflow pushes updates back to the PR branch (while keeping the same fork guard and checkout of `github.head_ref`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5143f9ba3fb90a12d4f271beef9df7433ad698b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->