### PR TITLE
ci: add --provenance to npm publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,8 +114,8 @@ jobs:
 
       - name: Publish to npm
         run: |
-          publish() {  # use latest npm to ensure OIDC support
-            npx -y npm@latest publish "$@"
+          publish() {  # use latest npm to ensure OIDC + provenance support
+            npx -y npm@latest publish --provenance "$@"
           }
           VERSION=$(jq -r .version package.json)
           if [[ $VERSION == *alpha* ]]; then


### PR DESCRIPTION
## Summary
- Adds `--provenance` to the `npm publish` invocation in `.github/workflows/ci.yml` so every release emits a Sigstore-verifiable attestation that consumers can check.
- The publish job already has `id-token: write`, which is what provenance needs.
- Trusted Publisher is already configured on on npmjs.com pinned to `PhenoML/phenoml-ts-sdk` + `ci.yml` so npm rejects publishes from any other repo/workflow even if an OIDC token leaks.

## Test plan
- [ ] Merge, then on next release confirm `npm view phenoml dist.attestations` is populated and the npmjs.com page shows the Provenance badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line CI publish flag change with no application or auth logic touched; relies on existing OIDC permissions.
> 
> **Overview**
> Release publishes from CI now pass **`--provenance`** to `npm publish`, so each package version gets a Sigstore-linked attestation tied to this workflow run. The helper comment is updated to note OIDC plus provenance; alpha/beta/stable tagging behavior is unchanged.
> 
> The **`publish`** job already grants **`id-token: write`**, which npm needs to attach provenance when using trusted publishing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ec6413cc0e043de2f2f05cd3756d028bdad306f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->