### PR TITLE
ci: isolate npm publish from dependency lifecycle scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,7 +162,12 @@ jobs:
         working-directory: artifact
         run: |
           TARBALL=$(ls *.tgz)
-          case "$TARBALL" in
+          # Match the version, not the tarball filename: the filename also
+          # carries the package name, which could spuriously contain
+          # alpha/beta. The tarball's own package.json is authoritative for
+          # the version being published.
+          VERSION=$(tar -xzOf "$TARBALL" package/package.json | jq -r .version)
+          case "$VERSION" in
             *alpha*) TAG=alpha ;;
             *beta*)  TAG=beta ;;
             *)       TAG=latest ;;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,13 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
 
       - name: Install pnpm
-        uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Install dependencies
         run: pnpm install
@@ -35,13 +35,13 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
 
       - name: Install pnpm
-        uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Install dependencies
         run: pnpm install
@@ -58,13 +58,13 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Set up node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
 
       - name: Install pnpm
-        uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
 
       - name: Install dependencies
         run: pnpm install
@@ -97,7 +97,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
         # Run before tag creation so a missing/stale spec doesn't leave a
         # ghost release (tag exists, npm publish skipped on retry because
         # the tag-existence check sets should_publish=false).
-        uses: PhenoML/sdk-shared-actions/verify-openapi-spec@1.0.2
+        uses: PhenoML/sdk-shared-actions/verify-openapi-spec@1.0.3
 
       - name: Extract version and check tag
         id: check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,16 +4,20 @@ on:
   push:
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   compile:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up node
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
 
       - name: Install pnpm
         uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
@@ -26,13 +30,15 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up node
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
 
       - name: Install pnpm
         uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
@@ -43,8 +49,45 @@ jobs:
       - name: Test
         run: pnpm test
 
-  tag:
+  build-artifact:
     needs: [compile, test]
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build
+        run: pnpm build
+
+      - name: Pack tarball and checksum
+        run: |
+          mkdir -p artifact
+          npm pack --pack-destination artifact
+          (cd artifact && sha256sum *.tgz > SHA256SUMS)
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: npm-package
+          path: artifact
+          if-no-files-found: error
+          retention-days: 7
+
+  tag:
+    needs: [compile, test, build-artifact]
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
@@ -54,7 +97,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
@@ -87,41 +130,41 @@ jobs:
             --generate-notes
 
   publish:
-    needs: [compile, test, tag]
+    needs: [compile, test, build-artifact, tag]
     if: needs.tag.outputs.should_publish == 'true'
     runs-on: ubuntu-latest
+    environment: npm-production
     permissions:
       contents: read
       id-token: write
 
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
+      # Node 24 ships npm >= 11.5, which supports OIDC Trusted Publishing
+      # without npx -y npm@latest (avoids running install scripts in the
+      # same job as the OIDC credential).
       - name: Set up node
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
+          node-version: '24'
           registry-url: "https://registry.npmjs.org"
 
-      - name: Install pnpm
-        uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
+      - name: Download artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: npm-package
+          path: artifact
 
-      - name: Install dependencies
-        run: pnpm install
-
-      - name: Build
-        run: pnpm build
+      - name: Verify checksum
+        working-directory: artifact
+        run: sha256sum -c SHA256SUMS
 
       - name: Publish to npm
+        working-directory: artifact
         run: |
-          publish() {  # use latest npm to ensure OIDC support
-            npx -y npm@latest publish "$@"
-          }
-          VERSION=$(jq -r .version package.json)
-          if [[ $VERSION == *alpha* ]]; then
-            publish --access public --tag alpha
-          elif [[ $VERSION == *beta* ]]; then
-            publish --access public --tag beta
-          else
-            publish --access public
-          fi
+          TARBALL=$(ls *.tgz)
+          case "$TARBALL" in
+            *alpha*) TAG=alpha ;;
+            *beta*)  TAG=beta ;;
+            *)       TAG=latest ;;
+          esac
+          npm publish --access public --tag "$TAG" "$TARBALL"

--- a/.github/workflows/sync-fern-artifacts.yml
+++ b/.github/workflows/sync-fern-artifacts.yml
@@ -20,6 +20,6 @@ jobs:
   sync:
     permissions:
       contents: write
-    uses: PhenoML/sdk-shared-actions/.github/workflows/sync-fern-artifacts.yml@1.0.2
+    uses: PhenoML/sdk-shared-actions/.github/workflows/sync-fern-artifacts.yml@1.0.3
     with:
       spec-path: openapi/openapi.json


### PR DESCRIPTION
## Summary

Reference implementation of step 1 of the three-SDK publish-hardening plan: keep the OIDC publish credential inside a job whose only inputs are a pre-built artifact and an upload command — no install, no third-party build plugins, no dependency lifecycle scripts in the same job as the credential.

- **New `build-artifact` job** runs the full toolchain (`pnpm install && pnpm build && npm pack`), checksums the tarball, and uploads `*.tgz` + `SHA256SUMS` via `actions/upload-artifact`.
- **`publish` job** is now `setup-node` → `download-artifact` → `sha256sum -c SHA256SUMS` → `npm publish <tarball>`. No checkout, no install, no build.
- **`tag` now waits on `build-artifact`** (`needs: [compile, test, build-artifact]`) so a pack/checksum/upload failure can't leave a ghost release — i.e. a version tag with nothing published that then makes every retry skip via `should_publish=false`.
- **Permissions hardened**: root `permissions: {}` with per-job declarations; `publish` scoped to a new `npm-production` GitHub Environment and limited to `contents: read, id-token: write`.
- **All `uses:` SHA-pinned** with `# vX.Y.Z`; bumped to current: `checkout@v6.0.3`, `setup-node@v6.4.0`, `pnpm/action-setup@v6.0.8`, new pins `upload-artifact@v7.0.1` + `download-artifact@v8.0.1`. `publish` pins Node 24 so bundled npm 11.5+ handles OIDC Trusted Publishing natively (drops `npx -y npm@latest`).
- `--provenance` is intentionally deferred per the plan; flip it on once a publish round-trips on the new topology.

## Deployment notes

- The `npm-production` Environment is auto-created on first use; add a deployment branch restriction (`refs/heads/main`) afterward as defense-in-depth — the `if: github.ref == 'refs/heads/main'` gate on `tag` already blocks publishes from other refs.
- Confirm the existing npm Trusted Publisher binding still points at this workflow path + `refs/heads/main` (workflow filename unchanged, so this should be unaffected).

## Test plan

- [ ] Push a no-op commit to `main` without a version bump: `compile`, `test`, `build-artifact` run; `tag` skips (existing version); `publish` skipped.
- [ ] Bump version + merge to `main`: `build-artifact` produces tarball + `SHA256SUMS`, `tag` creates the tag/release, `publish` downloads + verifies + publishes; confirm no install step appears in the publish job log.
- [ ] Confirm published package on npmjs.com matches expected version and dist-tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production npm publish topology and release ordering; mistakes could block publishes or mis-tag dist-tags, though supply-chain exposure in the publish job is reduced.
> 
> **Overview**
> **Hardens the main CI pipeline** so npm OIDC publishing runs only after a verified pre-built tarball, not in the same job as `pnpm install` / build tooling.
> 
> Adds a **`build-artifact`** job on `main` that builds, `npm pack`s, writes **SHA256SUMS**, and uploads the tarball. **`tag`** now depends on that job so a failed pack/upload cannot create a release tag with nothing to publish. **`publish`** drops checkout/install/build: it uses the **`npm-production`** environment, Node **24** for native OIDC npm, downloads the artifact, verifies checksums, and publishes the tarball—deriving **alpha/beta/latest** from the version inside the tarball’s `package.json`, not the filename.
> 
> Workflow-wide **`permissions: {}`** with per-job scopes, SHA-pinned action bumps, and **`sync-fern-artifacts`** bumped to shared actions **@1.0.3**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65f7a57ee6fc1cf7fa4901c6f15506827ef98e99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->