### PR TITLE
ci: bump sdk-shared-actions pins to 1.0.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
         # Run before tag creation so a missing/stale spec doesn't leave a
         # ghost release (tag exists, npm publish skipped on retry because
         # the tag-existence check sets should_publish=false).
-        uses: PhenoML/sdk-shared-actions/verify-openapi-spec@1.0.0
+        uses: PhenoML/sdk-shared-actions/verify-openapi-spec@1.0.2
 
       - name: Extract version and check tag
         id: check

--- a/.github/workflows/sync-fern-artifacts.yml
+++ b/.github/workflows/sync-fern-artifacts.yml
@@ -20,6 +20,6 @@ jobs:
   sync:
     permissions:
       contents: write
-    uses: PhenoML/sdk-shared-actions/.github/workflows/sync-fern-artifacts.yml@1.0.0
+    uses: PhenoML/sdk-shared-actions/.github/workflows/sync-fern-artifacts.yml@1.0.2
     with:
       spec-path: openapi/openapi.json


### PR DESCRIPTION
Bumps the `PhenoML/sdk-shared-actions` pins from `1.0.0` to the latest release tag `1.0.2`.

Two pins updated:
- `.github/workflows/sync-fern-artifacts.yml` — the reusable `sync-fern-artifacts` workflow
- `.github/workflows/ci.yml` — the `verify-openapi-spec` action

### What's in 1.0.0 → 1.0.2

- **`sync-fern-artifacts`:** the commit-back message now ends with `[skip ci]`, which suppresses the approval-gated ("1 workflow awaiting approval") phantom re-run that the `github-actions[bot]` artifact push triggers on public repos ([#29](https://github.com/PhenoML/sdk-shared-actions/issues/29)).
- The remaining 1.0.1/1.0.2 changes are release-please machinery fixes internal to the shared-actions repo.

No input or behavior changes for this repo beyond the pin bump.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-pin-only CI change with no application or release logic edits in this repo.
> 
> **Overview**
> Updates **`PhenoML/sdk-shared-actions`** references from **`1.0.0`** to **`1.0.2`** in two workflows: **`verify-openapi-spec`** in `ci.yml` (release tag job) and the reusable **`sync-fern-artifacts`** workflow.
> 
> This repo’s workflow inputs and steps are unchanged—only the pinned shared-action version moves. The newer sync workflow adds **`[skip ci]`** on artifact commit-backs upstream, which should reduce phantom approval-gated CI runs after bot pushes; OpenAPI verification behavior here stays the same aside from whatever fixes ship in that tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17560c14ceb84fcdea3fb5ab5f8d7f365ec197fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->